### PR TITLE
Initial commits for this Ansible role

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,22 +15,22 @@ all of which should be in this repository.
 
 If you want to report a bug or request a new feature, the most direct
 method is to [create an
-issue](https://github.com/cisagov/ansible-role-automated-security-updates/issues) in
-this repository.  We recommend that you first search through existing
-issues (both open and closed) to check if your particular issue has
-already been reported.  If it has then you might want to add a comment
-to the existing issue.  If it hasn't then feel free to create a new
-one.
+issue](https://github.com/cisagov/ansible-role-automated-security-updates/issues)
+in this repository.  We recommend that you first search through
+existing issues (both open and closed) to check if your particular
+issue has already been reported.  If it has then you might want to add
+a comment to the existing issue.  If it hasn't then feel free to
+create a new one.
 
 ## Pull requests ##
 
 If you choose to [submit a pull
-request](https://github.com/cisagov/ansible-role-automated-security-updates/pulls), you
-will notice that our continuous integration (CI) system runs a fairly
-extensive set of linters and syntax checkers.  Your pull request may
-fail these checks, and that's OK.  If you want you can stop there and
-wait for us to make the necessary corrections to ensure your code
-passes the CI checks.
+request](https://github.com/cisagov/ansible-role-automated-security-updates/pulls),
+you will notice that our continuous integration (CI) system runs a
+fairly extensive set of linters and syntax checkers.  Your pull
+request may fail these checks, and that's OK.  If you want you can
+stop there and wait for us to make the necessary corrections to ensure
+your code passes the CI checks.
 
 If you want to make the changes yourself, or if you want to become a
 regular contributor, then you will want to set up

--- a/README.md
+++ b/README.md
@@ -4,13 +4,8 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/cisagov/ansible-role-automated-security-updates.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-automated-security-updates/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-automated-security-updates.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-automated-security-updates/context:python)
 
-This is a skeleton project that can be used to quickly get a new
-[cisagov](https://github.com/cisagov) Ansible role GitHub project
-started.  This skeleton project contains
-[licensing information](LICENSE), as well as
-[pre-commit hooks](https://pre-commit.com) and
-[GitHub Actions](https://github.com/features/actions) configurations
-appropriate for an Ansible role.
+This is an Ansible role that sets up automated security updates on
+Debian- and RedHat-based Linux systems.
 
 ## Requirements ##
 
@@ -33,15 +28,8 @@ Here's how to use it in a playbook:
   become: yes
   become_method: sudo
   roles:
-    - skeleton
+    - automated_security_updates
 ```
-
-## New Repositories from a Skeleton ##
-
-Please see our [Project Setup guide](https://github.com/cisagov/development-guide/tree/develop/project_setup)
-for step-by-step instructions on how to start a new repository from
-a skeleton. This will save you time and effort when configuring a
-new repository!
 
 ## Contributing ##
 
@@ -63,4 +51,4 @@ with this waiver of copyright interest.
 
 ## Author Information ##
 
-First Last - <first.last@trio.dhs.gov>
+Shane Frasier - <jeremy.frasier@trio.dhs.gov>

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Shane Frasier
-  description: >
+  description: >-
     An Ansible role for for setting up automated security updates on
     Debian- and RedHat-based Linux systems.
   company: CISA Cyber Assessments

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -38,6 +38,6 @@ galaxy_info:
       versions:
         - bionic
         - focal
-  role_name: automated_updates
+  role_name: automated_security_updates
 
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,16 @@
 ---
 galaxy_info:
-  author: First Last
-  description: Skeleton Ansible role
+  author: Shane Frasier
+  description: >
+    An Ansible role for for setting up automated security updates on
+    Debian- and RedHat-based Linux systems.
   company: CISA Cyber Assessments
   galaxy_tags:
-    - skeleton
+    - apt
+    - aptitude
+    - automated
+    - dnf
+    - update
   license: CC0
   # With the release of version 2.10, Ansible finally correctly
   # identifies Kali Linux as being the Kali distribution of the Debian
@@ -32,6 +38,6 @@ galaxy_info:
       versions:
         - bionic
         - focal
-  role_name: skeleton
+  role_name: automated_updates
 
 dependencies: []

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,1 +1,1 @@
-molecule-no-systemd.yml
+molecule-with-systemd.yml

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,4 +1,30 @@
 ---
+# When installing packages during later steps, the Fedora Docker
+# images we are using (geerlingguy/docker-fedora32-ansible:latest and
+# cisagov/docker-fedora33-ansible:latest) can throw sporadic errors
+# like: "No such file or directory:
+# '/var/cache/dnf/metadata_lock.pid'".
+#
+# The fix is to ensure that systemd finishes initializing before
+# continuing on to the converge tasks.  For details see:
+# https://www.jeffgeerling.com/blog/2020/resolving-fedora-dnf-error-no-such-file-or-directory-varlibdnfrpmdblockpid
+- name: Group hosts by OS distribution
+  hosts: all
+  tasks:
+    - name: Group hosts by OS distribution
+      ansible.builtin.group_by:
+        key: os_{{ ansible_distribution }}
+- name: Wait for systemd to complete initialization (Fedora)
+  hosts: os_Fedora
+  tasks:
+    - name: Wait for systemd to complete initialization # noqa 303
+      ansible.builtin.command: systemctl is-system-running
+      register: systemctl_status
+      until: "'running' in systemctl_status.stdout"
+      retries: 30
+      delay: 5
+      when: ansible_service_mgr == 'systemd'
+
 - name: Import upgrade playbook
   ansible.builtin.import_playbook: upgrade.yml
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -4,7 +4,6 @@
 import os
 
 # Third-Party Libraries
-# import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -4,7 +4,7 @@
 import os
 
 # Third-Party Libraries
-import pytest
+# import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -12,7 +12,14 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("x", [True])
-def test_packages(host, x):
-    """Run a dummy test, just to show what one would look like."""
-    assert x
+def test_packages(host):
+    """Test that the expected packages were installed."""
+    distribution = host.system_info.distribution
+    if distribution in ["debian", "kali", "ubuntu"]:
+        assert host.package("apt-listchanges").is_installed
+        assert host.package("unattended-upgrades").is_installed
+    elif distribution in ["amzn", "fedora"]:
+        assert host.package("dnf-automatic").is_installed
+    else:
+        # This distribution is unsupported
+        assert False, f"Distribution {distribution} is not supported."

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -18,8 +18,10 @@ def test_packages(host):
     if distribution in ["debian", "kali", "ubuntu"]:
         assert host.package("apt-listchanges").is_installed
         assert host.package("unattended-upgrades").is_installed
-    elif distribution in ["amzn", "fedora"]:
+    elif distribution in ["fedora"]:
         assert host.package("dnf-automatic").is_installed
+    elif distribution in ["amzn"]:
+        assert host.package("yum-cron").is_installed
     else:
         # This distribution is unsupported
         assert False, f"Distribution {distribution} is not supported."

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -16,7 +16,6 @@ def test_packages(host):
     """Test that the expected packages were installed."""
     distribution = host.system_info.distribution
     if distribution in ["debian", "kali", "ubuntu"]:
-        assert host.package("apt-listchanges").is_installed
         assert host.package("unattended-upgrades").is_installed
     elif distribution in ["fedora"]:
         assert host.package("dnf-automatic").is_installed

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -24,3 +24,17 @@ def test_packages(host):
     else:
         # This distribution is unsupported
         assert False, f"Distribution {distribution} is not supported."
+
+
+def test_service_enabled(host):
+    """Test that the automatic upgrade service exists and was enabled."""
+    distribution = host.system_info.distribution
+    if distribution in ["debian", "kali", "ubuntu"]:
+        assert host.service("unattended-upgrades").is_enabled
+    elif distribution in ["fedora"]:
+        assert host.service("dnf-automatic").is_enabled
+    elif distribution in ["amzn"]:
+        assert host.service("yum-cron").is_enabled
+    else:
+        # This distribution is unsupported
+        assert False, f"Distribution {distribution} is not supported."

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -38,3 +38,33 @@ def test_service_enabled(host):
     else:
         # This distribution is unsupported
         assert False, f"Distribution {distribution} is not supported."
+
+
+def test_service_configuration(host):
+    """Test that the automatic upgrade service is configured as expected."""
+    distribution = host.system_info.distribution
+    if distribution in ["debian", "kali"]:
+        f = host.file("/etc/apt/apt.conf.d/50unattended-upgrades")
+        assert f.exists
+        assert f.is_file
+    elif distribution in ["ubuntu"]:
+        f = host.file("/etc/apt/apt.conf.d/50unattended-upgrades")
+        assert f.exists
+        assert f.is_file
+    elif distribution in ["fedora"]:
+        f = host.file("/etc/dnf/automatic.conf")
+        assert f.exists
+        assert f.is_file
+        assert f.contains(r"^upgrade_type = security$")
+        assert f.contains(r"^download_updates = yes$")
+        assert f.contains(r"^apply_updates = yes$")
+    elif distribution in ["amzn"]:
+        f = host.file("/etc/yum/yum-cron.conf")
+        assert f.exists
+        assert f.is_file
+        assert f.contains(r"^update_cmd = security$")
+        assert f.contains(r"^download_updates = yes$")
+        assert f.contains(r"^apply_updates = yes$")
+    else:
+        # This distribution is unsupported
+        assert False, f"Distribution {distribution} is not supported."

--- a/tasks/Amazon.yml
+++ b/tasks/Amazon.yml
@@ -1,0 +1,34 @@
+---
+- name: Configure yum-cron
+  block:
+    - name: Configure yum-cron to only consider security updates
+      ansible.builtin.lineinfile:
+        # This causes the line to be ignored if the regexp does not
+        # match anything.
+        backrefs: yes
+        line: update_cmd = security
+        path: /etc/yum/yum-cron.conf
+        regexp: ^upgrade_type = default$
+
+    - name: Configure yum-cron to download available updates
+      ansible.builtin.lineinfile:
+        # This causes the line to be ignored if the regexp does not
+        # match anything.
+        backrefs: yes
+        line: download_updates = yes
+        path: /etc/yum/yum-cron.conf
+        regexp: ^download_updates = no$
+
+    - name: Configure yum-cron to apply available updates
+      ansible.builtin.lineinfile:
+        # This causes the line to be ignored if the regexp does not
+        # match anything.
+        backrefs: yes
+        line: apply_updates = yes
+        path: /etc/yum/yum-cron.conf
+        regexp: ^apply_updates = no$
+
+- name: Enable yum-cron service
+  ansible.builtin.service:
+    name: yum-cron
+    enabled: yes

--- a/tasks/Amazon.yml
+++ b/tasks/Amazon.yml
@@ -27,8 +27,3 @@
         line: apply_updates = yes
         path: /etc/yum/yum-cron.conf
         regexp: ^apply_updates = no$
-
-- name: Enable yum-cron service
-  ansible.builtin.service:
-    name: yum-cron
-    enabled: yes

--- a/tasks/Amazon.yml
+++ b/tasks/Amazon.yml
@@ -8,7 +8,7 @@
         backrefs: yes
         line: update_cmd = security
         path: /etc/yum/yum-cron.conf
-        regexp: ^upgrade_type = default$
+        regexp: ^update_cmd = default$
 
     - name: Configure yum-cron to download available updates
       ansible.builtin.lineinfile:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -27,8 +27,3 @@
         # files don't accept that form of commenting.
         marker: // {mark} ANSIBLE MANAGED BLOCK
         path: /etc/apt/apt.conf.d/50unattended-upgrades
-
-- name: Enable unattended-upgrades service
-  ansible.builtin.service:
-    name: unattended-upgrades
-    enabled: yes

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,0 +1,34 @@
+---
+- name: Configure unattended-upgrade
+  block:
+    - name: Add Ansible blockinfile header
+      ansible.builtin.lineinfile:
+        insertbefore: ^Unattended-Upgrade::Origins-Pattern {
+        line: // BEGIN ANSIBLE MANAGED BLOCK
+        path: /etc/apt/apt.conf.d/50unattended-upgrades
+
+    - name: Add Ansible blockinfile footer
+      ansible.builtin.lineinfile:
+        # Note that relying on firstmatch here could be a little
+        # fragile
+        firstmatch: yes
+        insertafter: ^};$
+        line: // END ANSIBLE MANAGED BLOCK
+        path: /etc/apt/apt.conf.d/50unattended-upgrades
+
+    - name: Configure unattended-upgrade to only apply security updates
+      ansible.builtin.blockinfile:
+        block: |
+          // Only autoapply security updates
+          Unattended-Upgrade::Origins-Pattern {
+              "origin=${distro_id},codename=${distro_codename},label=${distro_id}-Security";
+          };
+        # We can't use the default marker here because the apt config
+        # files don't accept that form of commenting.
+        marker: // {mark} ANSIBLE MANAGED BLOCK
+        path: /etc/apt/apt.conf.d/50unattended-upgrades
+
+- name: Enable unattended-upgrades service
+  ansible.builtin.service:
+    name: unattended-upgrades
+    enabled: yes

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,0 +1,34 @@
+---
+- name: Configure dnf-automatic
+  block:
+    - name: Configure dnf-automatic to only consider security updates
+      ansible.builtin.lineinfile:
+        # This causes the line to be ignored if the regexp does not
+        # match anything.
+        backrefs: yes
+        line: upgrade_type = security
+        path: /etc/dnf/automatic.conf
+        regexp: ^upgrade_type = default$
+
+    - name: Configure dnf-automatic to download available updates
+      ansible.builtin.lineinfile:
+        # This causes the line to be ignored if the regexp does not
+        # match anything.
+        backrefs: yes
+        line: download_updates = yes
+        path: /etc/dnf/automatic.conf
+        regexp: ^download_updates = no$
+
+    - name: Configure dnf-automatic to apply available updates
+      ansible.builtin.lineinfile:
+        # This causes the line to be ignored if the regexp does not
+        # match anything.
+        backrefs: yes
+        line: apply_updates = yes
+        path: /etc/dnf/automatic.conf
+        regexp: ^apply_updates = no$
+
+- name: Enable dnf-automatic service
+  ansible.builtin.service:
+    name: dnf-automatic
+    enabled: yes

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -27,8 +27,3 @@
         line: apply_updates = yes
         path: /etc/dnf/automatic.conf
         regexp: ^apply_updates = no$
-
-- name: Enable dnf-automatic service
-  ansible.builtin.service:
-    name: dnf-automatic
-    enabled: yes

--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -1,0 +1,38 @@
+---
+# Ubuntu uses Allowed-Origins instead of Origins-Pattern in
+# /etc/apt/apt.conf.d/50unattended-upgrades, so its configuration is a
+# little different than that of Debian.
+- name: Configure unattended-upgrade
+  block:
+    - name: Add Ansible blockinfile header
+      ansible.builtin.lineinfile:
+        insertbefore: ^Unattended-Upgrade::Allowed-Origins {
+        line: // BEGIN ANSIBLE MANAGED BLOCK
+        path: /etc/apt/apt.conf.d/50unattended-upgrades
+
+    - name: Add Ansible blockinfile footer
+      ansible.builtin.lineinfile:
+        # Note that relying on firstmatch here could be a little
+        # fragile
+        firstmatch: yes
+        insertafter: ^};$
+        line: // END ANSIBLE MANAGED BLOCK
+        path: /etc/apt/apt.conf.d/50unattended-upgrades
+
+    - name: Configure unattended-upgrade to only apply security updates
+      ansible.builtin.blockinfile:
+        block: |
+          // Only autoapply security updates
+          Unattended-Upgrade::Allowed-Origins {
+              "${distro_id}:${distro_codename}-security";
+              // Extended Security Maintenance; doesn't necessarily exist for
+              // every release and this system may not have it installed, but if
+              // available, the policy for updates is such that unattended-upgrades
+              // should also install from here by default.
+              "${distro_id}ESMApps:${distro_codename}-apps-security";
+              "${distro_id}ESM:${distro_codename}-infra-security";
+          };
+        # We can't use the default marker here because the apt config
+        # files don't accept that form of commenting.
+        marker: // {mark} ANSIBLE MANAGED BLOCK
+        path: /etc/apt/apt.conf.d/50unattended-upgrades

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Load var file with package names based on the OS type
-  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars:
+    file: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,3 +14,15 @@
 - name: Install packages necessary for automated security updates
   ansible.builtin.package:
     name: "{{ package_names }}"
+
+- name: Include OS family- or distribution-specific configuration tasks
+  ansible.builtin.include_tasks:
+    file: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+      paths:
+        - "{{ role_path }}/tasks"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,15 @@
 ---
-# tasks file for skeleton
+- name: Load var file with package names based on the OS type
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+      paths:
+        - "{{ role_path }}/vars"
+
+- name: Install packages necessary for automated security updates
+  ansible.builtin.package:
+    name: "{{ package_names }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,3 +26,8 @@
         - "{{ ansible_os_family }}.yml"
       paths:
         - "{{ role_path }}/tasks"
+
+- name: Enable SystemD service that will perform the automated security updates
+  ansible.builtin.service:
+    name: "{{ service_name }}"
+    enabled: yes

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,0 +1,4 @@
+---
+# The packages to install for automated updates
+package_names:
+  - yum-cron

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -2,3 +2,7 @@
 # The packages to install for automated updates
 package_names:
   - yum-cron
+
+# The name of the SystemD service that will perform the automated
+# security updates
+service_name: yum-cron

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,6 @@
 ---
 # The packages to install for automated updates
 package_names:
-  - apt-listchanges
   - unattended-upgrades
 
 # The name of the SystemD service that will perform the automated

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,5 @@
+---
+# The packages to install for automated updates
+package_names:
+  - apt-listchanges
+  - unattended-upgrades

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,3 +3,7 @@
 package_names:
   - apt-listchanges
   - unattended-upgrades
+
+# The name of the SystemD service that will perform the automated
+# security updates
+service_name: unattended-upgrades

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,3 +2,7 @@
 # The packages to install for automated updates
 package_names:
   - dnf-automatic
+
+# The name of the SystemD service that will perform the automated
+# security updates
+service_name: dnf-automatic

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,4 @@
+---
+# The packages to install for automated updates
+package_names:
+  - dnf-automatic


### PR DESCRIPTION
## 🗣 Description ##

This pull request contains the initial commits for this Ansible role, which sets up automated security updates on Debian- and RedHat-based Linux systems.

## 💭 Motivation and context ##

Adding this Ansible role to our OpenVPN and FreeIPA AMIs will ensure that security updates are automatically applied to said instances even when they come out _between_ new AMI deployments.  This should make our security types happier, and cut down on the number of complaints we receive from them.

This Ansible role satisfies half the requirements of cisagov/cool-system#186.  The remaining requirements will be satisfied with future pull requests; I wanted to keep the automatic updates and the notifications separate, since the latter will require the use of AWS resources and are therefore more tied into our COOL infrastructure.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
