### PR TITLE
Enable dnf-automatic.timer instead of dnf-automatic.service on RedHat

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -31,7 +31,7 @@ def test_service_enabled(host):
     if distribution in ["debian", "kali", "ubuntu"]:
         assert host.service("unattended-upgrades").is_enabled
     elif distribution in ["fedora"]:
-        assert host.service("dnf-automatic").is_enabled
+        assert host.service("dnf-automatic.timer").is_enabled
     elif distribution in ["amzn"]:
         assert host.service("yum-cron").is_enabled
     else:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,6 +3,6 @@
 package_names:
   - dnf-automatic
 
-# The name of the SystemD service that will perform the automated
+# The name of the SystemD timer that will start the automated
 # security updates
 service_name: dnf-automatic.timer

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,4 +5,4 @@ package_names:
 
 # The name of the SystemD service that will perform the automated
 # security updates
-service_name: dnf-automatic
+service_name: dnf-automatic.timer


### PR DESCRIPTION
## 🗣 Description ##

This pull requests modifies the Ansible role to enable `dnf-automatic.timer` instead of `dnf-automatic.service` for RedHat systems.

## 💭 Motivation and context ##

`dnf-automatic.service` is a static unit, so it cannot be `enable`d or `disable`d; it can only be `start`ed and `stop`ped as is done in an automated fashion via the timer.  This bug was identified indirectly when it was noted that the automated updates are not being installed on COOL RedHat systems.

## 🧪 Testing ##

All `pre-commit` hooks and `molecule` tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
