### PR TITLE
Make Debian configuration less strict

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -21,7 +21,7 @@
         block: |
           // Only autoapply security updates
           Unattended-Upgrade::Origins-Pattern {
-              "origin=${distro_id},codename=${distro_codename},label=${distro_id}-Security";
+              "origin=${distro_id},label=${distro_id}-Security";
           };
         # We can't use the default marker here because the apt config
         # files don't accept that form of commenting.


### PR DESCRIPTION
## 🗣 Description ##

This pull request relaxes the constraints in the configuration for `unattended-upgrades` on Debian.

## 💭 Motivation and context ##

Resolves #24.

## 🧪 Testing ##

All automated tests pass.  I also made identical changes manually on the COOL staging VPN instance and verified that they functioned as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [ ] Build a new OpenVPN AMI with these changes.
