### PR TITLE
Bump testing platform to ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,12 +104,7 @@ jobs:
       matrix:
         scenario:
           - default
-    # TODO: We would prefer to run this job on ubuntu-latest, but
-    # Amazon Linux 2 has such an ancient version of SystemD (219) that
-    # it can't cope with cgroups v2.  We should revert to
-    # ubuntu-latest once cisagov/skeleton-ansible-role#131 is
-    # approved, merged, and pulled into this repo via Lineage.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - id: setup-python


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps the testing platform up to `ubuntu-latest`.

## 💭 Motivation and context ##

We can do this now that we are running the Molecule tests against Amazon Linux 2023 vice Amazon Linux 2, since the former understands cgroups v2.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.